### PR TITLE
e_iberia -> e_spain for compatibility

### DIFF
--- a/SWMH/common/landed_titles/landed_titles.txt
+++ b/SWMH/common/landed_titles/landed_titles.txt
@@ -31150,7 +31150,7 @@ e_france = {
 	}
 } # END e_france
 
-e_iberia = {
+e_spain = {
 	color={ 250 201 20 }
 	color2={ 255 255 255 }
 
@@ -39850,7 +39850,7 @@ e_iberia = {
 			culture_group = iberian
 			religion_group = christian
 			OR = {
-				has_landed_title = e_iberia
+				has_landed_title = e_spain
 				has_landed_title = k_castille 
 				has_landed_title = k_leon
 			}
@@ -39871,7 +39871,7 @@ e_iberia = {
 			culture_group = iberian
 			religion_group = christian
 			OR = {
-				has_landed_title = e_iberia
+				has_landed_title = e_spain
 				has_landed_title = k_castille 
 				has_landed_title = k_leon
 			}
@@ -39892,7 +39892,7 @@ e_iberia = {
 			culture_group = iberian
 			religion_group = christian
 			OR = {
-				has_landed_title = e_iberia
+				has_landed_title = e_spain
 				has_landed_title = k_castille 
 				has_landed_title = k_leon
 			}
@@ -39913,7 +39913,7 @@ e_iberia = {
 			culture_group = iberian
 			religion_group = christian
 			OR = {
-				has_landed_title = e_iberia
+				has_landed_title = e_spain
 				has_landed_title = k_castille 
 				has_landed_title = k_leon
 			}
@@ -39934,7 +39934,7 @@ e_iberia = {
 			culture_group = iberian
 			religion_group = christian
 			OR = {
-				has_landed_title = e_iberia
+				has_landed_title = e_spain
 				has_landed_title = k_castille 
 				has_landed_title = k_leon
 			}
@@ -39955,7 +39955,7 @@ e_iberia = {
 			culture_group = iberian
 			religion_group = christian
 			OR = {
-				has_landed_title = e_iberia
+				has_landed_title = e_spain
 				has_landed_title = k_aragon
 			}
 			OR = {
@@ -39975,7 +39975,7 @@ e_iberia = {
 			culture_group = iberian
 			religion_group = christian
 			OR = {
-				has_landed_title = e_iberia
+				has_landed_title = e_spain
 				has_landed_title = k_aragon
 			}
 			OR = {
@@ -40174,7 +40174,7 @@ e_iberia = {
 	} # END k_asturias
 
 # END TITULAR SWMH Spain
-} # END e_iberia
+} # END e_spain
 
 e_africa = {
 	color={ 204 1 1 }

--- a/SWMH/localisation/DuchiesKingdomsandEmpires de jure.csv
+++ b/SWMH/localisation/DuchiesKingdomsandEmpires de jure.csv
@@ -1,6 +1,6 @@
 #CODE;ENGLISH;FRENCH;GERMAN;;SPANISH;;;;;;;;;x
-e_iberia;España;España;España;;España;;;;;;;;;x
-e_iberia_adj;Española;Española;Española;;Española;;;;;;;;;x
+e_spain;España;España;España;;España;;;;;;;;;x
+e_spain_adj;Española;Española;Española;;Española;;;;;;;;;x
 e_scandinavia;Nordmannia;Nordmannia;Nordmannia;;Nordmannia;;;;;;;;;x
 e_scandinavia_adj;Nordmannian;Nordmannian;Nordmannian;;Nordmannian;;;;;;;;;x
 e_scandinavia_adj_norse;Norðr;Norðr;Norðr;;Norðr;;;;;;;;;x


### PR DESCRIPTION
e_iberia needs to be named e_spain internally so as to not break the parsing of vanilla events/decisions that assume e_spain exists. [There is no way to check whether it does in the script, so it must be corrected here.]

Anyway, this has no impact on the game other than allowing scripting to work.
