### PR TITLE
FIX: d_brunswick inherited wrong de jure liege from vanilla title history

### DIFF
--- a/SWMH/common/cultures/00_cultures.txt
+++ b/SWMH/common/cultures/00_cultures.txt
@@ -1638,7 +1638,6 @@ finno_ugric = {
 
 	finnish = {
 		graphical_culture = ugricgfx
-		
 		color = { 0.1 0.6 0.6 }
 
 		male_names = {

--- a/SWMH/history/titles/d_brunswick.txt
+++ b/SWMH/history/titles/d_brunswick.txt
@@ -1,0 +1,42 @@
+700.1.1 = {
+	liege = k_saxony
+	de_jure_liege = k_saxony
+}
+761.1.1={
+	holder = 190457 #Bruno
+}
+782.1.1={
+	holder = 0
+	liege = 0
+	
+# Nothing should be de jure vassal to k_germany in either 867 or 1066+ in SWMH,
+# so that's why this is commented-out (says ziji):
+#	
+#	de_jure_liege = k_germany
+}
+1235.1.1=
+{
+liege="e_hre"
+#law = agnatic_succession
+#law = succ_primogeniture
+}
+1235.1.1=
+{
+	holder = 462802
+}
+1252.1.1=
+{
+	holder = 462832
+}
+1262.1.1=
+{
+	holder = 462803
+}
+1279.1.1=
+{
+	holder = 462821
+}
+1318.9.22=
+{
+	holder = 462823
+}


### PR DESCRIPTION
In 2.2 (I assume), vanilla's title history for d_brunswick changed to make k_germany (supposed to be a titular title in SWMH) its de jure liege for 867 and beyond. In SWMH, it should've remained k_saxony, but SWMH did not override history/titles/d_brunswick.txt.

The result was that d_brunswick was a 1-duchy de jure kingdom (k_germany) that happened to be assigned the same exact color as k_franconia, a de jure kingdom to which it is adjacent, and thus was nearly impossible to spot on the de jure kingdom map mode.

I've fixed this by overriding the vanilla title history for d_brunswick and commenting-out the de_jure_liege=k_germany assignment in 782AD.
