### PR TITLE
Rebalanced Magyars: Take II

### DIFF
--- a/SWMH/history/characters/hungarian.txt
+++ b/SWMH/history/characters/hungarian.txt
@@ -9470,7 +9470,7 @@
 	culture="hungarian"
 	father=159138
 	mother=159139
-	martial=8
+	martial=9
 	diplomacy=7
 	trait=ambitious
 	trait=gregarious
@@ -9478,6 +9478,7 @@
 	trait=patient
 	trait=brilliant_strategist
 	trait=inspiring_leader
+	trait=defensive_leader
 	
 	810.1.1 = {
 		birth = yes
@@ -9488,8 +9489,10 @@
 
 		# NOTE: In patch 2.2, vanilla accidentally nerfed the Magyars compared to Bulgaria such that they literally
 		#       have zero chance of winning the war which leads to forming Hungary. They have been boosted a bit more
-		#       than vanilla here as a result so that the historical outcome of the war in 867.1.1 is actually possible
-		#       again. This is currently the only reason that this file, hungarian.txt, is overridden in SWMH.  --ziji
+		#       than vanilla here as a result so that the necessary outcome of the war in 867.1.1 is actually possible
+		#       again. This is currently the only reason that this file, hungarian.txt, is overridden in SWMH.  Also,
+		#       the vanilla army compositions were utterly ahistorical and anathemae to what we know about the Steppe
+		#       Magyars' culture and technology.  --ziji
 
 		effect = {
 			spawn_unit = {
@@ -9497,9 +9500,11 @@
 				owner = ROOT
 				leader = ROOT
 				troops = {
-					light_infantry = { 6992 6992 }
-					heavy_infantry = { 150 150 }
-					archers = { 700 700 }
+					archers = { 4096 4096 }
+					light_infantry = { 1024 1024 }
+					horse_archers = { 1024 1024 }
+					heavy_infantry = { 512 512 }
+					knights = { 384 384 }
 				}
 				attrition = 0.5
 			}
@@ -9511,10 +9516,10 @@
 				female = no
 				age = 23
 				attributes = {
-					martial = 6
+					martial = 8
 				}
 				trait = brilliant_strategist
-				trait = light_foot_leader
+				trait = flanker
 			}
 			new_character = {
 				spawn_unit = {
@@ -9522,9 +9527,11 @@
 					owner = ROOT
 					leader = THIS
 					troops = {
-						light_infantry = { 6992 6992 }
-						heavy_infantry = { 150 150 }
-						archers = { 700 700 }
+						archers = { 4096 4096 }
+						light_infantry = { 1024 1024 }
+						horse_archers = { 1024 1024 }
+						heavy_infantry = { 512 512 }
+						knights = { 384 384 }
 					}
 					attrition = 0.5
 				}
@@ -9537,10 +9544,10 @@
 				female = no
 				age = 27
 				attributes = {
-					martial = 6
+					martial = 8
 				}
 				trait = brilliant_strategist
-				trait = light_foot_leader
+				trait = aggressive_leader
 			}
 			new_character = {
 				spawn_unit = {
@@ -9548,11 +9555,14 @@
 					owner = ROOT
 					leader = THIS
 					troops = {
-						light_infantry = { 6992 6992 }
-						heavy_infantry = { 151 151 }
-						archers = { 699 699 }
+						archers = { 4096 4096 }
+						light_infantry = { 1024 1024 }
+						horse_archers = { 1024 1024 }
+						heavy_infantry = { 512 512 }
+						knights = { 384 384 }
 					}
 					attrition = 0.5
+					merge = yes
 				}
 			}
 		}


### PR DESCRIPTION
A second take on rebalancing the Magyar starting troops so that they can win their scripted invasion of Hungary in 867.  After observing more trials, it became clear that they were still losing terribly.  This was mostly an army composition issue.

While the new army compositions in this change require a little creative license to adapt to the Steppe Magyars' military traditions, they do result in the desired objective (a very good chance at winning the war with a small retinue remaining to help them survive afterward but still no guarantee of a victory & AI tendency to fully occupy the target kingdom to maximize effective conquest). They are at least not outright wrong, unlike the previous vanilla mix.
