### PR TITLE
A few assorted landed_titles fixes

### DIFF
--- a/SWMH/common/landed_titles/landed_titles.txt
+++ b/SWMH/common/landed_titles/landed_titles.txt
@@ -528,6 +528,94 @@ d_ibadi = {
 	}
 }
 
+d_kharijite = {
+	color={ 10 110 10 }
+	color2={ 220 220 0 }
+	
+	capital = 719 # Mecca
+	
+	creation_requires_capital = no
+	
+	dignity = 80 # Counted as having this many more counties than it does
+	
+	title = "CALIPH"
+	title_female = "CALIPHA"
+	foa = "CALIPH_FOA"
+	short_name = yes
+	
+	religion=kharijite
+	
+	# Controls a religion
+	controls_religion = kharijite
+	
+	allow = {
+		piety = 1000
+		OR = {
+			custom_tooltip = { 
+				text = controls_mecca_medina
+				hidden_tooltip = {
+					719 = { # Mecca
+						owner = {
+							OR = {
+								is_liege_or_above = ROOT
+								character = ROOT
+							}
+						}
+					}
+					718 = { # Medina
+						owner = {
+							OR = {
+								is_liege_or_above = ROOT
+								character = ROOT
+							}
+						}
+					}
+				}
+			}
+			custom_tooltip = {
+				text = controls_jerusalem_damascus_baghdad
+				hidden_tooltip = {
+					774 = { # Jerusalem
+						owner = {
+							OR = {
+								is_liege_or_above = ROOT
+								character = ROOT
+							}
+						}
+					}
+					728 = { # Damascus
+						owner = {
+							OR = {
+								is_liege_or_above = ROOT
+								character = ROOT
+							}
+						}
+					}
+					693 = { # Baghdad
+						owner = {
+							OR = {
+								is_liege_or_above = ROOT
+								character = ROOT
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	
+	caliphate = yes
+	
+	coat_of_arms=
+	{
+		data=
+		{
+			0 0 0 8 0 2 2
+		}
+		religion=kharijite
+	}
+}
+
 d_hurufi = {
 	color={ 80 220 80 }
 	color2={ 220 220 0 }

--- a/SWMH/common/landed_titles/swmh_landed_titles.txt
+++ b/SWMH/common/landed_titles/swmh_landed_titles.txt
@@ -53896,9 +53896,9 @@ e_seljuk_turks = { # Seljuk Turks
 	capital = 646 # Esfahan
 	culture = turkish
 	
-	tribe=yes
+#	tribe=yes
 	
-	landless = yes
+#	landless = yes
 	
 	allow = {
 		always = no
@@ -53929,6 +53929,28 @@ k_zirid = {
 k_ziyanids = {
 	color = { 5 76 194 }
 }
+k_avaria = {
+	color={ 250 120 90 }  # Only for the CoA
+	culture = avar
+	
+	capital = 444
+	
+	allow = {
+		always = no
+	}
+}
+k_lombardy = {
+	color={ 234 217 110 }  # Only for the CoA
+	culture = lombard
+	
+	capital = 234
+	
+	allow = {
+		always = no
+	}
+}
+
+
 k_makuria = {
 	color={ 165 180 95 }
 }


### PR DESCRIPTION
- added kharijite religious head title
- e_seljuk_turks was still tribe=yes (and landless=yes).  in vanilla,
  it is neither, and nothing is tribe=yes anymore. could be a part of
  recent weirdness (presumably last remaining tribe=yes title in SWMH).
- k_avaria and k_lombardy are used for CoAs in the 769 start.  inherited
  vanilla title history references them, so I added them.
